### PR TITLE
Include host and guest OS details

### DIFF
--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .environment import detect_environment
+from .os_info import update_environment_with_guest_os
 from .models import (
     CertificationDefinition,
     CertificationResult,
@@ -314,6 +315,7 @@ def execute_test(
     certification_version: str | None = None,
     qemu_binary: str | None = None,
     ovmf_path: str | None = None,
+    environment: dict[str, str | None] | None = None,
 ) -> TestResult:
     """Run a test, printing each step live as it executes."""
     started_at = datetime.now(timezone.utc).isoformat()
@@ -394,6 +396,8 @@ def execute_test(
                 else:
                     sr, new_launch = run_vm_launch_step(step, profile)
                     launch = new_launch
+                    if launch is not None and launch.ok and environment is not None:
+                        update_environment_with_guest_os(environment, launch.profile)
             elif step.kind == "vm_stop":
                 if launch is None:
                     sr = StepResult(
@@ -418,6 +422,8 @@ def execute_test(
                 else:
                     if launch is None:
                         launch = profile.vm_launch()
+                        if launch.ok and environment is not None:
+                            update_environment_with_guest_os(environment, launch.profile)
                     if not launch.ok:
                         sr = StepResult(
                             step=step,
@@ -487,6 +493,7 @@ def execute_certification(
     artifacts_root: Path,
     qemu_binary: str | None = None,
     ovmf_path: str | None = None,
+    environment: dict[str, str | None] | None = None,
 ) -> CertificationResult:
     """Run all tests in a certification with live output."""
     started_at = datetime.now(timezone.utc).isoformat()
@@ -511,6 +518,7 @@ def execute_certification(
             certification_version=cert.version,
             qemu_binary=qemu_binary,
             ovmf_path=ovmf_path,
+            environment=environment,
         )
         test_results.append(tr)
         if tr.result != "pass":
@@ -600,6 +608,8 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     _flush(f"   Guest:  {guest_path}")
+    if environment.get("host_os_pretty_name"):
+        _flush(f"   Host:   {environment['host_os_pretty_name']}")
     if environment.get("kernel_version"):
         _flush(f"   Kernel: {environment['kernel_version']}")
     if environment.get("qemu_version"):
@@ -629,6 +639,7 @@ def main(argv: list[str] | None = None) -> int:
                 certification_version=None,
                 qemu_binary=qemu_override,
                 ovmf_path=ovmf_override,
+                environment=environment,
             )
             prereq_results.append(tr)
             _flush("")
@@ -663,6 +674,7 @@ def main(argv: list[str] | None = None) -> int:
             artifacts_root=args.artifacts_dir,
             qemu_binary=qemu_override,
             ovmf_path=ovmf_override,
+            environment=environment,
         )
         cert_results.append(cr)
         total_tests += len(cr.test_results)

--- a/sev_verify/environment.py
+++ b/sev_verify/environment.py
@@ -1,10 +1,12 @@
-"""Detect host environment versions (QEMU, kernel, OVMF) for reporting."""
+"""Detect host environment versions (QEMU, kernel, OVMF, OS) for reporting."""
 
 from __future__ import annotations
 
 import platform
 import shutil
 import subprocess
+
+from .os_info import get_host_os_info
 
 
 def _get_qemu_version(binary: str) -> str | None:
@@ -78,9 +80,13 @@ def detect_environment(
 
     All detection is best-effort: failures produce ``None`` values.
     """
+    host_os = get_host_os_info()
     return {
         "qemu_version": _get_qemu_version(qemu_binary),
         "kernel_version": _get_kernel_version(),
         "ovmf_version": _get_ovmf_version(ovmf_path) if ovmf_path else None,
         "ovmf_path": ovmf_path,
+        "host_os_name": host_os.get("host_os_name"),
+        "host_os_release": host_os.get("host_os_release"),
+        "host_os_pretty_name": host_os.get("host_os_pretty_name"),
     }

--- a/sev_verify/os_info.py
+++ b/sev_verify/os_info.py
@@ -1,0 +1,128 @@
+"""Detect Host and Guest OS name and release information."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .vm_profile import VMProfile
+
+
+def _parse_os_release(content: str) -> dict[str, str]:
+    """Parse /etc/os-release content into a dict."""
+    result: dict[str, str] = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.strip('"').strip("'")
+        result[key] = value
+    return result
+
+
+def get_host_os_info(os_release_path: str = "/etc/os-release") -> dict[str, str | None]:
+    """Read host OS name and release from /etc/os-release.
+
+    Returns a dict with keys:
+        - host_os_name: e.g. "Fedora Linux"
+        - host_os_release: e.g. "41 (Server Edition)"
+        - host_os_pretty_name: e.g. "Fedora Linux 41 (Server Edition)"
+        - host_os_id: e.g. "fedora"
+    """
+    try:
+        content = Path(os_release_path).read_text()
+    except OSError:
+        return {
+            "host_os_name": None,
+            "host_os_release": None,
+            "host_os_pretty_name": None,
+            "host_os_id": None,
+        }
+
+    data = _parse_os_release(content)
+    return {
+        "host_os_name": data.get("NAME"),
+        "host_os_release": data.get("VERSION"),
+        "host_os_pretty_name": data.get("PRETTY_NAME"),
+        "host_os_id": data.get("ID"),
+    }
+
+
+def get_guest_os_info(profile: "VMProfile") -> dict[str, str | None]:
+    """Read guest OS name and release via vsock command.
+
+    Requires an active guest with vsock agent running.
+
+    Returns a dict with keys:
+        - guest_os_name: e.g. "Ubuntu"
+        - guest_os_release: e.g. "24.04 LTS (Noble Numbat)"
+        - guest_os_pretty_name: e.g. "Ubuntu 24.04 LTS"
+        - guest_os_id: e.g. "ubuntu"
+    """
+    from .guest_vsock import run_guest_command, GuestVsockError
+
+    try:
+        result = run_guest_command(profile, "cat /etc/os-release", timeout=10)
+        if result.exit_code != 0:
+            return {
+                "guest_os_name": None,
+                "guest_os_release": None,
+                "guest_os_pretty_name": None,
+                "guest_os_id": None,
+            }
+
+        data = _parse_os_release(result.stdout)
+        return {
+            "guest_os_name": data.get("NAME"),
+            "guest_os_release": data.get("VERSION"),
+            "guest_os_pretty_name": data.get("PRETTY_NAME"),
+            "guest_os_id": data.get("ID"),
+        }
+    except GuestVsockError:
+        return {
+            "guest_os_name": None,
+            "guest_os_release": None,
+            "guest_os_pretty_name": None,
+            "guest_os_id": None,
+        }
+
+
+def format_os_info(os_info: dict[str, str | None]) -> str | None:
+    """Format OS info dict into a single display string.
+
+    Prefers PRETTY_NAME if available, otherwise combines NAME and VERSION.
+    Returns None if no info is available.
+    """
+    pretty = os_info.get("host_os_pretty_name") or os_info.get("guest_os_pretty_name")
+    if pretty:
+        return pretty
+
+    name = os_info.get("host_os_name") or os_info.get("guest_os_name")
+    release = os_info.get("host_os_release") or os_info.get("guest_os_release")
+
+    if name and release:
+        return f"{name} {release}"
+    return name or release or None
+
+
+def update_environment_with_guest_os(
+    environment: dict[str, str | None],
+    profile: "VMProfile",
+) -> None:
+    """Update environment dict in-place with guest OS information.
+
+    Requires an active guest with vsock agent. Silently skips if guest
+    info cannot be retrieved.
+    """
+    if environment.get("guest_os_pretty_name"):
+        return
+
+    guest_info = get_guest_os_info(profile)
+    environment["guest_os_name"] = guest_info.get("guest_os_name")
+    environment["guest_os_release"] = guest_info.get("guest_os_release")
+    environment["guest_os_pretty_name"] = guest_info.get("guest_os_pretty_name")
+    environment["guest_os_id"] = guest_info.get("guest_os_id")

--- a/sev_verify/output.py
+++ b/sev_verify/output.py
@@ -145,8 +145,22 @@ def write_markdown(
 
     if environment:
         env_lines: list[str] = []
+        if environment.get("host_os_pretty_name"):
+            env_lines.append(f"- **Host OS:** {environment['host_os_pretty_name']}")
+        elif environment.get("host_os_name"):
+            host_os = environment["host_os_name"]
+            if environment.get("host_os_release"):
+                host_os = f"{host_os} {environment['host_os_release']}"
+            env_lines.append(f"- **Host OS:** {host_os}")
         if environment.get("kernel_version"):
             env_lines.append(f"- **Host kernel:** {environment['kernel_version']}")
+        if environment.get("guest_os_pretty_name"):
+            env_lines.append(f"- **Guest OS:** {environment['guest_os_pretty_name']}")
+        elif environment.get("guest_os_name"):
+            guest_os = environment["guest_os_name"]
+            if environment.get("guest_os_release"):
+                guest_os = f"{guest_os} {environment['guest_os_release']}"
+            env_lines.append(f"- **Guest OS:** {guest_os}")
         if environment.get("qemu_version"):
             env_lines.append(f"- **QEMU:** {environment['qemu_version']}")
         if environment.get("ovmf_version"):


### PR DESCRIPTION
Add os_info module to detect OS name/version from /etc/os-release on both host (local file) and guest (via vsock). 
Display OS info in CLI output and include it in the markdown report section.

Sample Generated Markdown File shows the below content:
<img width="1049" height="808" alt="image" src="https://github.com/user-attachments/assets/11b8dab0-5b54-44dc-ac27-ef946b815bd9" />
